### PR TITLE
Re-design: Grid system

### DIFF
--- a/src/game.cpp
+++ b/src/game.cpp
@@ -102,8 +102,10 @@ namespace Game
         return false;
     }
 
+    GridObject::GridObject(BrickShape t_shape, sf::Vector2f t_pos) : shape(t_shape), position(t_pos) {}
+
     Brick::Brick(BrickShape t_shape, std::shared_ptr<sf::Texture> t_texture, sf::Vector2f t_pos)
-        : shape(t_shape), texture(t_texture), position(t_pos)
+        : GridObject(t_shape, t_pos), texture(t_texture)
     {
         for (size_t i = 0; i < BRICK_MATRIX_SIZE; i++)
         {
@@ -123,13 +125,13 @@ namespace Game
         }
     };
 
-    void Brick::debug_print_pos()
+    void GridObject::debug_print_pos()
     {
         std::cout << "Position X: " << position.x << "  Y: " << position.y
                   << "  --  Width:" << shape.width << "  Height:" << shape.height << '\n';
     }
 
-    void Brick::move_right()
+    void GridObject::move_right()
     {
         auto new_position = position + sf::Vector2f(single_brick_size, 0.0f);
         if (new_position.x + (shape.width * single_brick_size) > right_border)
@@ -139,7 +141,7 @@ namespace Game
         debug_print_pos();
     }
 
-    void Brick::move_left()
+    void GridObject::move_left()
     {
         auto new_position = position + sf::Vector2f(-single_brick_size, 0.0f);
         if (new_position.x < left_border)
@@ -149,7 +151,7 @@ namespace Game
         debug_print_pos();
     }
 
-    void Brick::move_up()
+    void GridObject::move_up()
     {
         auto new_position = position + sf::Vector2f(0.0f, -single_brick_size);
         if (new_position.y < upper_border)
@@ -159,7 +161,7 @@ namespace Game
         debug_print_pos();
     }
 
-    void Brick::move_down()
+    void GridObject::move_down()
     {
         auto new_position = position + sf::Vector2f(0.0f, single_brick_size);
         if (new_position.y + (shape.height * single_brick_size) > lower_border)

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -104,27 +104,6 @@ namespace Game
 
     GridObject::GridObject(BrickShape t_shape, sf::Vector2f t_pos) : shape(t_shape), position(t_pos) {}
 
-    Brick::Brick(BrickShape t_shape, std::shared_ptr<sf::Texture> t_texture, sf::Vector2f t_pos)
-        : GridObject(t_shape, t_pos), texture(t_texture)
-    {
-        for (size_t i = 0; i < BRICK_MATRIX_SIZE; i++)
-        {
-            for (size_t j = 0; j < BRICK_MATRIX_SIZE; j++)
-            {
-                char cell = shape.shape[i][j];
-                if (cell)
-                {
-                    auto sprite = sf::Sprite();
-                    sprite.setTexture(*texture);
-                    sprite.setScale(sf::Vector2f(single_brick_size, single_brick_size));
-                    sprite.setPosition(position + sf::Vector2f(j * single_brick_size, i * single_brick_size));
-
-                    sprites.push_back(std::move(sprite));
-                }
-            }
-        }
-    };
-
     void GridObject::debug_print_pos()
     {
         std::cout << "Position X: " << position.x << "  Y: " << position.y
@@ -170,6 +149,27 @@ namespace Game
         position = new_position;
         debug_print_pos();
     }
+
+    Brick::Brick(BrickShape t_shape, std::shared_ptr<sf::Texture> t_texture, sf::Vector2f t_pos)
+        : GridObject(t_shape, t_pos), texture(t_texture)
+    {
+        for (size_t i = 0; i < BRICK_MATRIX_SIZE; i++)
+        {
+            for (size_t j = 0; j < BRICK_MATRIX_SIZE; j++)
+            {
+                char cell = shape.shape[i][j];
+                if (cell)
+                {
+                    auto sprite = sf::Sprite();
+                    sprite.setTexture(*texture);
+                    sprite.setScale(sf::Vector2f(single_brick_size, single_brick_size));
+                    sprite.setPosition(position + sf::Vector2f(j * single_brick_size, i * single_brick_size));
+
+                    sprites.push_back(std::move(sprite));
+                }
+            }
+        }
+    };
 
     void Brick::apply_sprite_positions()
     {

--- a/src/game.h
+++ b/src/game.h
@@ -47,25 +47,25 @@ namespace Game
         void slide_up();
     };
 
-    class Brick
+    class GridObject
     {
     public:
-        Brick() = delete;
-        Brick(BrickShape t_shape, std::shared_ptr<sf::Texture> t_texture, sf::Vector2f t_pos);
+        GridObject() = delete;
+        GridObject(BrickShape t_shape, sf::Vector2f t_pos);
 
         BrickShape shape;
-        std::shared_ptr<sf::Texture> texture;
         sf::Vector2f position;
+        
         std::vector<sf::Sprite> sprites;
 
-        void apply_sprite_positions();
+        virtual void apply_sprite_positions() = 0;
 
         void move_right();
         void move_left();
         void move_up();
         void move_down();
 
-    private:
+    protected:
         constexpr static float single_brick_size = 50.0f;
 
         constexpr static int left_border = 50;
@@ -74,6 +74,18 @@ namespace Game
         constexpr static int lower_border = 800;
 
         void debug_print_pos();
+    };
+
+    class Brick : public GridObject
+    {
+    public:
+        Brick() = delete;
+        Brick(BrickShape t_shape, std::shared_ptr<sf::Texture> t_texture, sf::Vector2f t_pos);
+
+        std::shared_ptr<sf::Texture> texture;
+
+    public:
+        void apply_sprite_positions() override;
     };
 
     class Scene

--- a/src/game.h
+++ b/src/game.h
@@ -14,6 +14,9 @@
 namespace Game
 {
 
+    template <typename Type, size_t row, size_t col>
+    using Matrix = std::array<std::array<Type, col>, row>;
+
     class Timer
     {
     public:
@@ -55,7 +58,7 @@ namespace Game
 
         BrickShape shape;
         sf::Vector2f position;
-        
+
         std::vector<sf::Sprite> sprites;
 
         virtual void apply_sprite_positions() = 0;
@@ -97,6 +100,11 @@ namespace Game
 
         std::map<std::string, std::shared_ptr<sf::Drawable>> objects;
         std::vector<Brick> brick_objects;
+
+        constexpr static size_t grid_height = 15;
+        constexpr static size_t grid_width = 10;
+
+        Matrix<std::shared_ptr<GridObject>, grid_width, grid_height> grid_objects;
 
     protected:
         template <typename ShapeType, typename... ArgType>

--- a/src/game.h
+++ b/src/game.h
@@ -104,7 +104,7 @@ namespace Game
         constexpr static size_t grid_height = 15;
         constexpr static size_t grid_width = 10;
 
-        Matrix<std::shared_ptr<GridObject>, grid_width, grid_height> grid_objects;
+        Matrix<std::shared_ptr<std::weak_ptr<sf::Sprite>>, grid_width, grid_height> grid;
 
     protected:
         template <typename ShapeType, typename... ArgType>


### PR DESCRIPTION
Önceki tasarımda bütün objeler ayrı render ediliyordu, böyle bir durumda birbiriyle olan ilişkilerini karşılaştırmak çok zorlaşıyor.

Onun yerine grid sistemine geçiyoruz. Sahnenin ortasında bir matris var ve objelerin sprite'ları bu matris üzerinde hareket edecek.